### PR TITLE
pass add argument as a const reference

### DIFF
--- a/RingBufCPP.h
+++ b/RingBufCPP.h
@@ -23,7 +23,7 @@ RingBufCPP()
 *  Add element obj to the buffer
 * Return: true on success
 */
-bool add(Type &obj)
+bool add(const Type &obj)
 {
     bool ret = false;
     RB_ATOMIC_START


### PR DESCRIPTION
The argument should be const, because it is not modified in the function, and that allow to pass rvalues (eg a const value) to the function.