### PR TITLE
Add atomic operations for Nordic nRF52 SDK, refactor code and docs

### DIFF
--- a/RingBufCPP.h
+++ b/RingBufCPP.h
@@ -3,155 +3,171 @@
 
 #include "RingBufHelpers.h"
 
-template <typename Type, size_t MaxElements>
-class RingBufCPP
-{
+/**
+ * A simple ring (FIFO) buffer with concurrency protection built in, thus being
+ * safe to perform operations on the buffer inside of ISR's. All memory is
+ * statically allocated at compile time, so no heap memory is used. It can
+ * buffer any fixed size object (ints, floats, structs, objects, etc...).
+ *
+ * @tparam Type        Type of the elements being stored.
+ * @tparam MaxElements Maximum number of elements in this buffer. Note that
+ *                     the allocated memory size will be at least
+ *                     `MaxElements * sizeof(Type)`.
+ */
+template<typename Type, size_t MaxElements>
+class RingBufCPP {
 public:
 
-RingBufCPP()
-{
-     RB_ATOMIC_START
-     {
-         _numElements = 0;
-
-         _head = 0;
-     }
-     RB_ATOMIC_END
-}
-
-/**
-*  Add element obj to the buffer
-* Return: true on success
-*/
-bool add(const Type &obj)
-{
-    bool ret = false;
-    RB_ATOMIC_START
-    {
-        if (!isFull()) {
-            _buf[_head] = obj;
-            _head = (_head + 1)%MaxElements;
-            _numElements++;
-
-            ret = true;
-        }
+    RingBufCPP() {
+        RB_ATOMIC_START
+            {
+                _numElements = 0;
+                _head = 0;
+            }
+        RB_ATOMIC_END
     }
-    RB_ATOMIC_END
 
-    return ret;
-}
+    /**
+     *  Add an element to the buffer.
+     *
+     *  @param obj[in] The element to add.
+     *
+     *  @return true on success.
+     */
+    bool add(const Type &obj) {
+        bool ret = false;
 
+        RB_ATOMIC_START
+            {
+                if (!isFull()) {
+                    _buf[_head] = obj;
+                    _head = (_head + 1) % MaxElements;
+                    _numElements++;
 
-/**
-* Remove last element from buffer, and copy it to dest
-* Return: true on success
-*/
-bool pull(Type *dest)
-{
-    bool ret = false;
-    size_t tail;
+                    ret = true;
+                }
+            }
+        RB_ATOMIC_END
 
-    RB_ATOMIC_START
-    {
-        if (!isEmpty()) {
-            tail = getTail();
-            *dest = _buf[tail];
-            _numElements--;
-
-            ret = true;
-        }
+        return ret;
     }
-    RB_ATOMIC_END
-
-    return ret;
-}
 
 
-/**
-* Peek at num'th element in the buffer
-* Return: a pointer to the num'th element
-*/
-Type* peek(size_t num)
-{
-    Type *ret = NULL;
+    /**
+     * Remove last element from buffer, and copy it to destination.
+     *
+     * @param dest[out] Pointer on the allocated object to which removed element
+     *                  will be copied.
+     *
+     * @return true on success.
+     */
+    bool pull(Type *dest) {
+        bool ret = false;
+        size_t tail;
 
-    RB_ATOMIC_START
-    {
-        if (num < _numElements) //make sure not out of bounds
-            ret = &_buf[(getTail() + num)%MaxElements];
+        RB_ATOMIC_START
+            {
+                if (!isEmpty()) {
+                    tail = getTail();
+                    *dest = _buf[tail];
+                    _numElements--;
+
+                    ret = true;
+                }
+            }
+        RB_ATOMIC_END
+
+        return ret;
     }
-    RB_ATOMIC_END
-
-    return ret;
-}
 
 
-/**
-* Return: true if buffer is full
-*/
-bool isFull() const
-{
-    bool ret;
+    /**
+     * Peek at n'th element in the buffer.
+     *
+     * @param num Index of the element to peek at. As this is FIFO buffer, the
+     *            oldest element in the buffer is always at index 0 and the
+     *            last added one is at the index `numElements() - 1`.
+     *
+     * @return A pointer to the num'th element or `nullptr` if there is less
+     *         elements currently in the buffer than provided index.
+     */
+    Type *peek(size_t num) {
+        Type *ret = nullptr;
 
-    RB_ATOMIC_START
-    {
-        ret = _numElements >= MaxElements;
+        RB_ATOMIC_START
+            {
+                if (num < _numElements) //make sure not out of bounds
+                    ret = &_buf[(getTail() + num) % MaxElements];
+            }
+        RB_ATOMIC_END
+
+        return ret;
     }
-    RB_ATOMIC_END
-
-    return ret;
-}
 
 
-/**
-* Return: number of elements in buffer
-*/
-size_t numElements() const
-{
-    size_t ret;
+    /**
+     * @return true if buffer is full.
+     */
+    bool isFull() const {
+        bool ret;
 
-    RB_ATOMIC_START
-    {
-        ret = _numElements;
+        RB_ATOMIC_START
+            {
+                ret = _numElements >= MaxElements;
+            }
+        RB_ATOMIC_END
+
+        return ret;
     }
-    RB_ATOMIC_END
-
-    return ret;
-}
 
 
-/**
-* Return: true if buffer is empty
-*/
-bool isEmpty() const
-{
-    bool ret;
+    /**
+     * @return number of elements currently in buffer.
+     */
+    size_t numElements() const {
+        size_t ret;
 
-    RB_ATOMIC_START
-    {
-        ret = !_numElements;
+        RB_ATOMIC_START
+            {
+                ret = _numElements;
+            }
+        RB_ATOMIC_END
+
+        return ret;
     }
-    RB_ATOMIC_END
 
-    return ret;
-}
+
+    /**
+     * @return true if buffer is empty.
+     */
+    bool isEmpty() const {
+        bool ret;
+
+        RB_ATOMIC_START
+            {
+                ret = !_numElements;
+            }
+        RB_ATOMIC_END
+
+        return ret;
+    }
 
 protected:
-/**
-* Calculates the index in the array of the oldest element
-* Return: index in array of element
-*/
-size_t getTail() const
-{
-    return (_head + (MaxElements - _numElements))%MaxElements;
-}
+    /**
+     * Calculates the index of the oldest element in the array.
+     *
+     * @return index of the element in array.
+     */
+    size_t getTail() const {
+        return (_head + (MaxElements - _numElements)) % MaxElements;
+    }
 
 
-// underlying array
-Type _buf[MaxElements];
+    /** Underlying array. */
+    Type _buf[MaxElements];
 
-size_t _head;
-size_t _numElements;
+    size_t _head;
+    size_t _numElements;
 private:
 
 };

--- a/RingBufHelpers.h
+++ b/RingBufHelpers.h
@@ -1,15 +1,18 @@
 #ifndef EM_RINGBUF_HELPERS_CPP_H
 #define EM_RINGBUF_HELPERS_CPP_H
 
-// TODO fix this
-#ifndef NULL
-    #define NULL (void *)(0)
-#endif
 
 #ifdef ARDUINO
     #include <Arduino.h>
+#elif (defined(NRF51) || defined(NRF52) || defined(NRF52_SERIES))
+    // One of those defines is mandatory otherwise error is thrown in nrf.h
+    #ifndef NORDIC_NRF5x
+        #define NORDIC_NRF5x 1 // Common include for Nordic nRF5 SDK
+    #endif // NORDIC_NRF5x
+
+    #include "app_util_platform.h"
 #else
-    #include <stdint.h>
+    #include <stdint.h> // NOLINT
 #endif
 
 #ifdef ARDUINO
@@ -39,15 +42,18 @@
     #else
         #define RB_ATOMIC_START {
         #define RB_ATOMIC_END }
-        #warning “This library only fully supports AVR and ESP8266 Boards.”
+        #warning "This library only fully supports AVR and ESP8266 Boards."
         #warning "Operations on the buffer in ISRs are not safe!"
     #endif
 
+#elif defined(NORDIC_NRF5x)
+    #define RB_ATOMIC_START CRITICAL_REGION_ENTER()
+    #define RB_ATOMIC_END CRITICAL_REGION_EXIT()
 #else
     #define RB_ATOMIC_START {
     #define RB_ATOMIC_END }
     #warning "Operations on the buffer in ISRs are not safe!"
-    #warning "Impliment RB_ATOMIC_START and RB_ATOMIC_END macros for safe ISR operation!"
+    #warning "Implement RB_ATOMIC_START and RB_ATOMIC_END macros for safe ISR operation!"
 #endif
 
 #endif

--- a/examples_no_arduino/test.cpp
+++ b/examples_no_arduino/test.cpp
@@ -1,27 +1,26 @@
-#include <stdio.h>
-#include "RingBuf.h"
-#include <stdint.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
+#include "RingBufCPP.h"
 
-int main()
-{
+
+int main() {
     RingBufCPP<int, 5> q;
-    int tmp = 12;
-    //q.add(tmp);
+    int tmp = -1;
 
-    for (uint16_t i=0; i< 100; i++) {
-        int tmp = random();
+    for (uint16_t i = 0; i < 100; i++) {
+        tmp = rand(); // NOLINT
 
         if (q.add(tmp)) {
             printf("Added %d\n", tmp);
         }
         else {
             q.pull(&tmp);
+            printf("Buffer is full. Pulled %d\n", tmp);
             break;
         }
     }
 
-    while(!q.isEmpty()) {
+    while (!q.isEmpty()) {
         int pulled;
         q.pull(&pulled);
         printf("Got %d\n", pulled);


### PR DESCRIPTION
Add atomic operations for Nordic nRF52 SDK, refactor code and documentation

- Also fix test.cpp, change Arduino's `random()` to stdlib's `rand()`
- Conform CLion's warnings `Clang-Tidy: Inclusion of deprecated C++ header 'std*.h'`