### PR TITLE
fix quotes

### DIFF
--- a/RingBufHelpers.h
+++ b/RingBufHelpers.h
@@ -39,7 +39,7 @@
     #else
         #define RB_ATOMIC_START {
         #define RB_ATOMIC_END }
-        #warning “This library only fully supports AVR and ESP8266 Boards.”
+        #warning "This library only fully supports AVR and ESP8266 Boards."
         #warning "Operations on the buffer in ISRs are not safe!"
     #endif
 


### PR DESCRIPTION
I had a compile error:
.pio/libdeps/d1_mini/RingBufCPP/RingBufHelpers.h:42:18: error: extended character “ is not valid in an identifier
   42 |         #warning “This library only fully supports AVR and ESP8266 Boards.”

This commit fixes the issue for me.